### PR TITLE
feat(#19): require uuids to edit submissions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,9 +2,11 @@ class ApplicationController < ActionController::Base
   before_action :http_authenticate, only: [:new, :create, :edit, :update, :destroy]
  
   def http_authenticate
-    return true unless Rails.env == 'production'
+    # return true unless Rails.env == 'production'
     authenticate_or_request_with_http_basic do |username, password|
-        username == ENV['HTTP_AUTH_USERNAME'] && password == ENV['HTTP_AUTH_PASSWORD']
+        expected_username = ENV['HTTP_AUTH_USERNAME'] || 'cluutch'
+        expected_password = ENV['HTTP_AUTH_PASSWORD'] || 'cluutch.io'
+        username == expected_username && password == expected_password
     end
   end
 end

--- a/app/controllers/v2/quotes_submissions_controller.rb
+++ b/app/controllers/v2/quotes_submissions_controller.rb
@@ -1,5 +1,6 @@
 class V2::QuotesSubmissionsController < ApplicationController
   before_action :set_v2_quotes_submission, only: %w[ show edit update destroy ]
+  before_action :http_authenticate, only: [:new, :create, :destroy, :index]
 
   # GET /v2/quotes_submissions
   # GET /v2/quotes_submissions.json
@@ -28,7 +29,7 @@ class V2::QuotesSubmissionsController < ApplicationController
 
     respond_to do |format|
       if @v2_quotes_submission.save
-        format.html { redirect_to @v2_quotes_submission, notice: "Quotes submission was successfully created." }
+        format.html { redirect_to v2_quotes_submission_path(@v2_quotes_submission, uuid: @v2_quotes_submission.uuid), notice: "Quotes submission was successfully created." }
         format.json { render :show, status: :created, location: @v2_quotes_submission }
       else
         format.html { render :new, status: :unprocessable_entity }
@@ -41,8 +42,10 @@ class V2::QuotesSubmissionsController < ApplicationController
   # PATCH/PUT /v2/quotes_submissions/1.json
   def update
     respond_to do |format|
-      if @v2_quotes_submission.update(v2_quotes_submission_params)
-        format.html { redirect_to @v2_quotes_submission, notice: "Quotes submission was successfully updated." }
+      if !@v2_quotes_submission.is_confirmed && @v2_quotes_submission.update(v2_quotes_submission_params)
+        puts "UPDATED"
+        puts @v2_quotes_submission.uuid
+        format.html { redirect_to v2_quotes_submission_path(@v2_quotes_submission, uuid: @v2_quotes_submission.uuid), notice: "Quotes submission was successfully updated." }
         format.json { render :show, status: :ok, location: @v2_quotes_submission }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -64,11 +67,12 @@ class V2::QuotesSubmissionsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_v2_quotes_submission
-      @v2_quotes_submission = V2::QuotesSubmission.find(params[:id])
+      uuid = params[:uuid] || params[:v2_quotes_submission][:uuid]
+      @v2_quotes_submission = V2::QuotesSubmission.find_by(uuid: uuid, id: params[:id])
     end
 
     # Only allow a list of trusted parameters through.
     def v2_quotes_submission_params
-      params.require(:v2_quotes_submission).permit(quotes_attributes: [:price_per_ounce, :v2_jurisdiction_id])
+      params.require(:v2_quotes_submission).permit(quotes_attributes: [:id, :price_per_ounce, :v2_jurisdiction_id, :date, :vendor_name, :vendor_url, :vendor_branch, :is_primary])
     end
 end

--- a/app/models/v2/quotes_submission.rb
+++ b/app/models/v2/quotes_submission.rb
@@ -1,7 +1,10 @@
+require "securerandom"
+
 class V2::QuotesSubmission < ApplicationRecord
   has_many :quotes, class_name: "V2::Quote", inverse_of: :quotes_submission, foreign_key: :v2_quotes_submission_id
   accepts_nested_attributes_for :quotes
-
+  before_save :set_uuids
+  before_save :set_is_confirmed
 
   def self.new_prefilled_form
     prefilled_quotes = [
@@ -42,5 +45,16 @@ class V2::QuotesSubmission < ApplicationRecord
     end
 
     return submission
+  end
+
+  private
+
+  def set_uuids
+    self.uuid = SecureRandom.uuid unless uuid.present?
+    self.confirmation_token = SecureRandom.uuid unless confirmation_token.present?
+  end
+
+  def set_is_confirmed
+    self.is_confirmed = quotes.all? { |quote| quote.price_per_ounce.present? }
   end
 end

--- a/app/views/v2/quotes_submissions/_form.html.erb
+++ b/app/views/v2/quotes_submissions/_form.html.erb
@@ -1,3 +1,17 @@
+  <h1>Quotes Submission Form</h1>
+
+  <p><strong>Instructions: Click the link below to review the Website. Find the cheapest ounce of weed and enter the price. Follow these rules for knowing which price to use:</strong></p>
+
+  <ul>
+    <li>Do not change the location from the link provided. If the link is to a marketplace, do not select a different vendor. If a specific city is selected, don't change cities.</li>
+    <li>Only consider "flower". Do not consider edibles, concentrates, hash, or any form of weed other than the bud.</li>
+    <li>An ounce is 28g. Always use the prices for product closest in weight to an ounce without going over. If ounce prices are available, use those.</li>
+    <li>If there are no prices for exactly an ounce, use multiples of the largest quantity available, without going over. For example, if 1/2 oz. (14g) is selling for $100 cheapest, then the cheapest price for an ounce is $200.</li>
+    <li>Do not use prices if they are for more than an ounce. If 2 oz. (56g) are available, do not use their prices. Use the closest quantity for sale less than or equal to an ounce.</li>
+    <li>Only consider products that contain some THC. CBD or other types of flower are not to be counted.</li>
+    <li>Sativa vs indica is not relevant. Neither are growing conditions, THC concentration, or other attributes. As long as the price is for THC containing flower, it can be included.</li>
+  </ul>
+
 <%= simple_form_for @v2_quotes_submission do |f| %>
   <%= f.simple_fields_for :quotes do |quote_form| %>
     <div class="my-4">
@@ -14,6 +28,7 @@
   <% end %> 
 
   <div class="d-grid gap-2 my-3">
-   <button type="submit" class="btn btn-primary btn-lg">Submit</button>
+    <%= f.hidden_field :uuid %>
+    <button type="submit" class="btn btn-primary btn-lg">Submit</button>
   </div>
 <% end %>

--- a/app/views/v2/quotes_submissions/edit.html.erb
+++ b/app/views/v2/quotes_submissions/edit.html.erb
@@ -3,6 +3,6 @@
 
   <%= render 'form', v2_quotes_submission: @v2_quotes_submission %>
 
-  <%= link_to 'Show', @v2_quotes_submission %> |
+  <%= link_to 'Show', v2_quotes_submission_path(@v2_quotes_submission, uuid: @v2_quotes_submission.uuid) %> |
   <%= link_to 'Back', v2_quotes_submissions_path %>
 </div>

--- a/app/views/v2/quotes_submissions/index.html.erb
+++ b/app/views/v2/quotes_submissions/index.html.erb
@@ -12,8 +12,8 @@
   <tbody>
     <% @v2_quotes_submissions.each do |v2_quotes_submission| %>
       <tr>
-        <td><%= link_to 'Show', v2_quotes_submission %></td>
-        <td><%= link_to 'Edit', edit_v2_quotes_submission_path(v2_quotes_submission) %></td>
+        <td><%= link_to "#{v2_quotes_submission.is_confirmed} #{v2_quotes_submission.uuid}", edit_v2_quotes_submission_path(v2_quotes_submission, 
+          uuid: v2_quotes_submission.uuid) %></td>
         <td><%= link_to 'Destroy', v2_quotes_submission, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>

--- a/app/views/v2/quotes_submissions/new.html.erb
+++ b/app/views/v2/quotes_submissions/new.html.erb
@@ -1,21 +1,4 @@
 <div class="container">
-  <h1>Quotes Submission Form</h1>
-
-    <p><strong>Instructions: Click the link below to review the Website. Find the cheapest ounce of weed and enter the price. Follow these rules for knowing which price to use:</strong></p>
-
-    <ul>
-      <li>Only consider "flower". Do not consider edibles, concentrates, hash, or any form of weed other than the bud.</li>
-
-      <li>An ounce is 28g. Always use the prices for product closest in weight to an ounce without going over. If ounce prices are available, use those.</li>
-
-      <li>If there are no prices for exactly an ounce, use multiples of the largest quantity available, without going over. For example, if 1/2 oz. (14g) is selling for $100 cheapest, then the cheapest price for an ounce is $200.</li>
-
-      <li>Do not use prices if they are for more than an ounce. If 2 oz. (56g) are available, do not use their prices. Use the closest quantity for sale less than or equal to an ounce.</li>
-
-      <li>Only consider products that contain some THC. CBD or other types of flower are not to be counted.</li>
-
-      <li>Sativa vs indica is not relevant. Neither are growing conditions, THC concentration, or other attributes. As long as the price is for THC containing flower, it can be included.</li>
-    </ul>
   <%= render 'form', v2_quotes_submission: @v2_quotes_submission %>
 
   <%= link_to 'Back', v2_quotes_submissions_path %>

--- a/app/views/v2/quotes_submissions/show.html.erb
+++ b/app/views/v2/quotes_submissions/show.html.erb
@@ -1,8 +1,13 @@
 <p id="notice"><%= notice %></p>
+<% if @v2_quotes_submission.is_confirmed %>
+  <h2>Confirmation token: <%= @v2_quotes_submission.confirmation_token %></h2>
+<% else %>
+  <h2>Confirmed: <%= @v2_quotes_submission.is_confirmed %></h2>
+<% end %>
 
 <% @v2_quotes_submission.quotes.each do |quote| %>
   <h2><%= quote.price_per_ounce %></h2>
 <% end %>
 
-<%= link_to 'Edit', edit_v2_quotes_submission_path(@v2_quotes_submission) %> |
+<%= link_to 'Edit',  edit_v2_quotes_submission_path(@v2_quotes_submission, uuid: @v2_quotes_submission.uuid) %> |
 <%= link_to 'Back', v2_quotes_submissions_path %>

--- a/db/migrate/20210307212546_enable_pgcrypto.rb
+++ b/db/migrate/20210307212546_enable_pgcrypto.rb
@@ -1,0 +1,5 @@
+class EnablePgcrypto < ActiveRecord::Migration[6.1]
+  def change
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/migrate/20210307212911_add_uuid_and_validation_token_to_v2_quotes_submissions.rb
+++ b/db/migrate/20210307212911_add_uuid_and_validation_token_to_v2_quotes_submissions.rb
@@ -1,0 +1,9 @@
+class AddUuidAndValidationTokenToV2QuotesSubmissions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :v2_quotes_submissions, :uuid, :uuid
+    add_index :v2_quotes_submissions, :uuid
+
+    add_column :v2_quotes_submissions, :confirmation_token, :uuid
+    add_index :v2_quotes_submissions, :confirmation_token
+  end
+end

--- a/db/migrate/20210307213424_add_is_confirmed_to_v2_quotes_submissions.rb
+++ b/db/migrate/20210307213424_add_is_confirmed_to_v2_quotes_submissions.rb
@@ -1,0 +1,5 @@
+class AddIsConfirmedToV2QuotesSubmissions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :v2_quotes_submissions, :is_confirmed, :boolean, default: false, nullable: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_07_020105) do
+ActiveRecord::Schema.define(version: 2021_03_07_213424) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "quotes", force: :cascade do |t|
@@ -51,6 +52,11 @@ ActiveRecord::Schema.define(version: 2021_03_07_020105) do
   create_table "v2_quotes_submissions", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "uuid"
+    t.uuid "confirmation_token"
+    t.boolean "is_confirmed", default: false
+    t.index ["confirmation_token"], name: "index_v2_quotes_submissions_on_confirmation_token"
+    t.index ["uuid"], name: "index_v2_quotes_submissions_on_uuid"
   end
 
   add_foreign_key "v2_quotes", "v2_jurisdictions"

--- a/spec/models/v2/quotes_submission_spec.rb
+++ b/spec/models/v2/quotes_submission_spec.rb
@@ -13,4 +13,21 @@ RSpec.describe V2::QuotesSubmission, type: :model do
     
     expect(submission.quotes[6].price_per_ounce).to be_nil
   end
+
+  it 'has a uuid and confirmation token that does not change' do
+    submission = V2::QuotesSubmission.create
+
+    uuid = submission.uuid
+    expect(uuid).to be_truthy
+
+    confirmation_token = submission.confirmation_token
+    expect(confirmation_token).to be_truthy
+
+    # force a new save
+    submission.update(is_confirmed: true)
+
+    # expect no changes
+    expect(submission.uuid).to eq(uuid)
+    expect(submission.confirmation_token).to eq(confirmation_token)
+  end
 end


### PR DESCRIPTION
Added uuids and confirmation tokens to submissions.
Lookup by uuid and id when updating.
Don't allow submission to be updated after it has been confirmed.
Show confirmation token if everything correctly inputted.

closes #19 