### PR TITLE
feat: add endpoint to create quotes submissions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery unless: -> { request.format.json? }
   before_action :http_authenticate, only: [:new, :create, :edit, :update, :destroy]
  
   def http_authenticate

--- a/app/controllers/v2/quotes_submissions_controller.rb
+++ b/app/controllers/v2/quotes_submissions_controller.rb
@@ -1,6 +1,6 @@
 class V2::QuotesSubmissionsController < ApplicationController
   before_action :set_v2_quotes_submission, only: %w[ show edit update destroy ]
-  before_action :http_authenticate, only: [:new, :create, :destroy, :index]
+  before_action :http_authenticate, only: [:new, :create, :destroy, :index, :gen]
 
   # GET /v2/quotes_submissions
   # GET /v2/quotes_submissions.json
@@ -16,6 +16,18 @@ class V2::QuotesSubmissionsController < ApplicationController
   # GET /v2/quotes_submissions/new
   def new
     @v2_quotes_submission = V2::QuotesSubmission.new_prefilled_form
+  end
+
+  # POST
+  def gen
+    @v2_quotes_submission = V2::QuotesSubmission.new_prefilled_form
+    respond_to do |format|
+      if @v2_quotes_submission.save 
+        format.json { render template: "v2/quotes_submissions/show", status: :created }
+      else
+        format.json { render json: @v2_quotes_submission.errors, status: :unprocessable_entity }
+      end
+    end
   end
 
   # GET /v2/quotes_submissions/1/edit

--- a/app/views/v2/quotes_submissions/_v2_quotes_submission.jbuilder
+++ b/app/views/v2/quotes_submissions/_v2_quotes_submission.jbuilder
@@ -1,0 +1,2 @@
+json.extract! v2_quotes_submission, :id, :uuid, :created_at
+json.url edit_v2_quotes_submission_url(v2_quotes_submission, uuid: v2_quotes_submission[:uuid])

--- a/app/views/v2/quotes_submissions/_v2_quotes_submission.json.jbuilder
+++ b/app/views/v2/quotes_submissions/_v2_quotes_submission.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! v2_quotes_submission, :id, :created_at, :updated_at
-json.url v2_quotes_submission_url(v2_quotes_submission, format: :json)

--- a/app/views/v2/quotes_submissions/show.json.jbuilder
+++ b/app/views/v2/quotes_submissions/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! "v2_quotes_submissions/v2_quotes_submission", v2_quotes_submission: @v2_quotes_submission
+json.partial! "v2/quotes_submissions/v2_quotes_submission", v2_quotes_submission: @v2_quotes_submission

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     resources :quotes
     resources :jurisdictions
     resources :quotes_submissions
+    post 'quotes_submissions/gen', to: 'quotes_submissions#gen', module: :v2, defaults: { format: 'json' }
     get 'daily', to: 'dailies#index'
   end
 


### PR DESCRIPTION
Prefill data using v2/quotes_submissions/gen endpoint.
Unrelated, allow POST requests via JSON.

closes #42 